### PR TITLE
Update SVC and Paper Build on Creative Spawn

### DIFF
--- a/jars.yaml
+++ b/jars.yaml
@@ -40,5 +40,5 @@ plugins:
   name: PaperTweaks
   version: 0.4.0
 version:
-  build: 381
+  build: 496
   name: 1.20.4

--- a/jars.yaml
+++ b/jars.yaml
@@ -15,9 +15,9 @@ plugins:
 - checksum: 942946199c475658e5b82f09eed69eba078ed3b0
   name: CarbonChat
   version: 2.1.0-beta.23
-- checksum: c8d03b8ae3c226faedc7a0c4117ad9de59606414
+- checksum: 72af4feefb7c986907aba9dd009ce258654d2fce
   name: voicechat
-  version: 2.4.30
+  version: 2.5.13
 - checksum: e4866a50200229eeae91ea1faf6bc87f623e70c1
   name: FreedomChat
   version: 1.5.2


### PR DESCRIPTION
Again, title says it all.

Both SVC and Paper are updated for the same reason on Survival. SVC is updated to allow support for 1.20.6 and Paper Build is updated so that the version is kept at its latest.