### PR TITLE
Remove redstone wiring from disallowed blocks.

### DIFF
--- a/plugins/FastAsyncWorldEdit/config.yml
+++ b/plugins/FastAsyncWorldEdit/config.yml
@@ -393,7 +393,6 @@ limits:
     disallowed-blocks: 
     - "minecraft:wheat"
     - "minecraft:fire"
-    - "minecraft:redstone_wire"
     # List of block properties that should be remapped if used in an edit. Entries should take the form
     # "property_name[value1_old:value1_new,value2_old:value2_new]". For example:
     #  - "waterlogged[true:false]"


### PR DESCRIPTION
This PR removes redstone_wire from the disallowed blocks list in creative.