### PR TITLE
Re-add redstone wires to the disallowed blocks for FAWE

### DIFF
--- a/plugins/FastAsyncWorldEdit/config.yml
+++ b/plugins/FastAsyncWorldEdit/config.yml
@@ -396,9 +396,10 @@ limits:
     #  - "minecraft:conduit[waterlogged=true]"
     #  - "minecraft:piston[extended=false,facing=west]"
     #  - "minecraft:wheat[age=7]"
-    disallowed-blocks: 
+    disallowed-blocks:
     - "minecraft:wheat"
     - "minecraft:fire"
+    - "minecraft:redstone_wire"
     # List of block properties that should be remapped if used in an edit. Entries should take the form
     # "property_name[value1_old:value1_new,value2_old:value2_new]". For example:
     #  - "waterlogged[true:false]"


### PR DESCRIPTION
This PR re-adds redstone wire to the disallowed blocks for Fast Async World Edit as it seems to cause sporadic crashes when interacting with them.